### PR TITLE
ref: Hashi as optional | AMB

### DIFF
--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -29,7 +29,7 @@ contract BasicBridge is
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = 0x916daedf6915000ff68ced2f0b6773fe6f2582237f92c3c95bb4d79407230071; // keccak256(abi.encodePacked("requiredBlockConfirmations"))
     bytes32 internal constant HASHI_MANAGER = 0x660d8ed18395a9aa930e304e0bb5e6e51957af1fa215b11db48bfda3dd38d511; // keccak256(abi.encodePacked("hashiManager"))
     bool public constant HASHI_IS_ENABLED = true;
-    bool public constant HASHI_IS_OPTIONAL = true;
+    bool public constant HASHI_IS_MANDATORY = false;
 
     function isApprovedByHashi(bytes32 msgId) public view returns (bool) {
         return boolStorage[keccak256(abi.encodePacked("messagesApprovedByHashi", msgId))];

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -29,6 +29,11 @@ contract BasicBridge is
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = 0x916daedf6915000ff68ced2f0b6773fe6f2582237f92c3c95bb4d79407230071; // keccak256(abi.encodePacked("requiredBlockConfirmations"))
     bytes32 internal constant HASHI_MANAGER = 0x660d8ed18395a9aa930e304e0bb5e6e51957af1fa215b11db48bfda3dd38d511; // keccak256(abi.encodePacked("hashiManager"))
     bool public constant HASHI_IS_ENABLED = true;
+    bool public constant HASHI_IS_OPTIONAL = true;
+
+    function isApprovedByHashi(bytes32 msgId) public view returns (bool) {
+        return boolStorage[keccak256(abi.encodePacked("messagesApprovedByHashi", msgId))];
+    }
 
     /**
     * @dev Public setter for fallback gas price value. Only bridge owner can call this method.
@@ -71,6 +76,10 @@ contract BasicBridge is
     function _setGasPrice(uint256 _gasPrice) internal {
         uintStorage[GAS_PRICE] = _gasPrice;
         emit GasPriceChanged(_gasPrice);
+    }
+
+    function _setHashiApprovalForMessage(bytes32 msgId, bool status) internal {
+        boolStorage[keccak256(abi.encodePacked("messagesApprovedByHashi", msgId))] = status;
     }
 
     function _maybeRelayDataWithHashi(bytes data) internal {

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicForeignAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicForeignAMB.sol
@@ -107,7 +107,6 @@ contract BasicForeignAMB is BasicAMB, MessageRelay, MessageDelivery {
         require(_isMessageVersionValid(msgId));
         require(_isDestinationChainIdValid(chainIds[1]));
         require(!relayedMessages(msgId));
-        // NOTE: If Hashi is optional, a message can be executed even if it hasn't been approved by Hashi
         if (HASHI_IS_ENABLED && HASHI_IS_MANDATORY) require(isApprovedByHashi(msgId));
         setRelayedMessages(msgId, true);
         processMessage(sender, executor, msgId, gasLimit, dataType, chainIds[0], data);

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicForeignAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicForeignAMB.sol
@@ -108,7 +108,7 @@ contract BasicForeignAMB is BasicAMB, MessageRelay, MessageDelivery {
         require(_isDestinationChainIdValid(chainIds[1]));
         require(!relayedMessages(msgId));
         // NOTE: If Hashi is optional, a message can be executed even if it hasn't been approved by Hashi
-        if (HASHI_IS_ENABLED && !HASHI_IS_OPTIONAL) require(isApprovedByHashi(msgId));
+        if (HASHI_IS_ENABLED && HASHI_IS_MANDATORY) require(isApprovedByHashi(msgId));
         setRelayedMessages(msgId, true);
         processMessage(sender, executor, msgId, gasLimit, dataType, chainIds[0], data);
     }

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
@@ -33,7 +33,6 @@ contract BasicHomeAMB is BasicAMB, MessageDelivery {
 
         emit SignedForAffirmation(msg.sender, hashMsg);
 
-        // NOTE: If Hashi is optional, an affirmation can be executed even if it hasn't been approved by Hashi
         if (HASHI_IS_ENABLED && HASHI_IS_MANDATORY) {
             (bytes32 msgId, ) = ArbitraryMessage.unpackData(message);
             require(isApprovedByHashi(msgId));

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
@@ -34,7 +34,7 @@ contract BasicHomeAMB is BasicAMB, MessageDelivery {
         emit SignedForAffirmation(msg.sender, hashMsg);
 
         // NOTE: If Hashi is optional, an affirmation can be executed even if it hasn't been approved by Hashi
-        if (HASHI_IS_ENABLED && !HASHI_IS_OPTIONAL) {
+        if (HASHI_IS_ENABLED && HASHI_IS_MANDATORY) {
             (bytes32 msgId, ) = ArbitraryMessage.unpackData(message);
             require(isApprovedByHashi(msgId));
         }

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
@@ -33,7 +33,13 @@ contract BasicHomeAMB is BasicAMB, MessageDelivery {
 
         emit SignedForAffirmation(msg.sender, hashMsg);
 
-        if (signed >= requiredSignatures() && !HASHI_IS_ENABLED) {
+        // NOTE: If Hashi is optional, an affirmation can be executed even if it hasn't been approved by Hashi
+        if (HASHI_IS_ENABLED && !HASHI_IS_OPTIONAL) {
+            (bytes32 msgId, ) = ArbitraryMessage.unpackData(message);
+            require(isApprovedByHashi(msgId));
+        }
+
+        if (signed >= requiredSignatures()) {
             setNumAffirmationsSigned(hashMsg, markAsProcessed(signed));
             handleMessage(message);
         }
@@ -46,15 +52,8 @@ contract BasicHomeAMB is BasicAMB, MessageDelivery {
                 chainId == hashiManager().hashiTargetChainId() &&
                 sender == hashiManager().hashiTargetAddress()
         );
-
-        bytes32 hashMsg = keccak256(abi.encodePacked(message));
-        uint256 signed = numAffirmationsSigned(hashMsg);
-        // NOTE: preventing double execution if HASHI_IS_ENABLED = true on the foreign chain
-        //  and HASHI_IS_ENABLED = false on the home chain
-        require(!isAlreadyProcessed(signed));
-        require(signed >= requiredSignatures());
-        setNumAffirmationsSigned(hashMsg, markAsProcessed(signed));
-        handleMessage(message);
+        (bytes32 msgId, ) = ArbitraryMessage.unpackData(message);
+        _setHashiApprovalForMessage(msgId, true);
     }
 
     /**


### PR DESCRIPTION
This pr introduces the possibility of having Hashi as optional. If `HASHI_IS_OPTIONAL=true`, a message can be executed also without waiting the Hashi confirmation.