### PR TITLE
ref: Hashi as optional | xDAI bridge

### DIFF
--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -29,7 +29,7 @@ contract BasicBridge is
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = 0x916daedf6915000ff68ced2f0b6773fe6f2582237f92c3c95bb4d79407230071; // keccak256(abi.encodePacked("requiredBlockConfirmations"))
     bytes32 internal constant HASHI_MANAGER = 0x660d8ed18395a9aa930e304e0bb5e6e51957af1fa215b11db48bfda3dd38d511; // keccak256(abi.encodePacked("hashiManager"))
     bool public constant HASHI_IS_ENABLED = true;
-    bool public constant HASHI_IS_OPTIONAL = true;
+    bool public constant HASHI_IS_MANDATORY = false;
 
     function isApprovedByHashi(bytes32 msgId) public view returns (bool) {
         return boolStorage[keccak256(abi.encodePacked("messagesApprovedByHashi", msgId))];

--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -29,6 +29,11 @@ contract BasicBridge is
     bytes32 internal constant REQUIRED_BLOCK_CONFIRMATIONS = 0x916daedf6915000ff68ced2f0b6773fe6f2582237f92c3c95bb4d79407230071; // keccak256(abi.encodePacked("requiredBlockConfirmations"))
     bytes32 internal constant HASHI_MANAGER = 0x660d8ed18395a9aa930e304e0bb5e6e51957af1fa215b11db48bfda3dd38d511; // keccak256(abi.encodePacked("hashiManager"))
     bool public constant HASHI_IS_ENABLED = true;
+    bool public constant HASHI_IS_OPTIONAL = true;
+
+    function isApprovedByHashi(bytes32 msgId) public view returns (bool) {
+        return boolStorage[keccak256(abi.encodePacked("messagesApprovedByHashi", msgId))];
+    }
 
     /**
     * @dev Public setter for fallback gas price value. Only bridge owner can call this method.
@@ -71,6 +76,10 @@ contract BasicBridge is
     function _setGasPrice(uint256 _gasPrice) internal {
         uintStorage[GAS_PRICE] = _gasPrice;
         emit GasPriceChanged(_gasPrice);
+    }
+
+    function _setHashiApprovalForMessage(bytes32 msgId, bool status) internal {
+        boolStorage[keccak256(abi.encodePacked("messagesApprovedByHashi", msgId))] = status;
     }
 
     function _maybeRelayDataWithHashi(bytes data) internal {

--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -33,7 +33,7 @@ contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge, BasicTo
             setRelayedMessages(nonce, true);
 
             bytes32 msgId = keccak256(abi.encodePacked(recipient, amount, nonce));
-            if (HASHI_IS_ENABLED && !HASHI_IS_OPTIONAL) require(isApprovedByHashi(msgId));
+            if (HASHI_IS_ENABLED && HASHI_IS_MANDATORY) require(isApprovedByHashi(msgId));
 
             require(onExecuteMessage(recipient, amount, nonce));
             emit RelayedMessage(recipient, amount, nonce);

--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -33,8 +33,7 @@ contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge, BasicTo
             setRelayedMessages(nonce, true);
 
             bytes32 msgId = keccak256(abi.encodePacked(recipient, amount, nonce));
-            if (HASHI_IS_ENABLED) require(canBeExecuted(msgId));
-            _setMessageToExecute(msgId, false);
+            if (HASHI_IS_ENABLED && !HASHI_IS_OPTIONAL) require(isApprovedByHashi(msgId));
 
             require(onExecuteMessage(recipient, amount, nonce));
             emit RelayedMessage(recipient, amount, nonce);
@@ -52,7 +51,7 @@ contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge, BasicTo
         );
         // NOTE: message contains recipient, amount, nonce
         bytes32 msgId = keccak256(message);
-        _setMessageToExecute(msgId, true);
+        _setHashiApprovalForMessage(msgId, true);
     }
 
     function _emitUserRequestForAffirmationMaybeRelayDataWithHashiAndIncreaseNonce(address _receiver, uint256 _amount)

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -50,7 +50,6 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge, BasicToken
 
             emit SignedForAffirmation(msg.sender, nonce);
 
-            // NOTE: If Hashi is optional, an affirmation can be executed even if it hasn't been approved by Hashi
             if (HASHI_IS_ENABLED && HASHI_IS_MANDATORY) require(isApprovedByHashi(hashMsg));
 
             if (signed >= requiredSignatures()) {

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -51,7 +51,7 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge, BasicToken
             emit SignedForAffirmation(msg.sender, nonce);
 
             // NOTE: If Hashi is optional, an affirmation can be executed even if it hasn't been approved by Hashi
-            if (HASHI_IS_ENABLED && !HASHI_IS_OPTIONAL) require(isApprovedByHashi(hashMsg));
+            if (HASHI_IS_ENABLED && HASHI_IS_MANDATORY) require(isApprovedByHashi(hashMsg));
 
             if (signed >= requiredSignatures()) {
                 // If the bridge contract does not own enough tokens to transfer


### PR DESCRIPTION
This pr introduces the possibility of having Hashi as optional. If HASHI_IS_OPTIONAL=true, a message can be executed also without waiting the Hashi confirmation.