### PR TITLE
feat: add possibility to resend an hashi message [AMB]

### DIFF
--- a/contracts/upgradeable_contracts/arbitrary_message/BasicForeignAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicForeignAMB.sol
@@ -122,6 +122,7 @@ contract BasicForeignAMB is BasicAMB, MessageRelay, MessageDelivery {
     ) external returns (bytes) {
         _validateHashiMessage(chainId, threshold, sender, adapters);
         (bytes32 msgId, ) = ArbitraryMessage.unpackData(data);
+        require(!isApprovedByHashi(msgId));
         _setHashiApprovalForMessage(msgId, true);
     }
 

--- a/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/BasicHomeAMB.sol
@@ -54,6 +54,7 @@ contract BasicHomeAMB is BasicAMB, MessageDelivery {
     ) external returns (bytes) {
         _validateHashiMessage(chainId, threshold, sender, adapters);
         (bytes32 msgId, ) = ArbitraryMessage.unpackData(data);
+        require(!isApprovedByHashi(msgId));
         _setHashiApprovalForMessage(msgId, true);
     }
 

--- a/contracts/upgradeable_contracts/arbitrary_message/MessageDelivery.sol
+++ b/contracts/upgradeable_contracts/arbitrary_message/MessageDelivery.sol
@@ -63,7 +63,7 @@ contract MessageDelivery is BasicAMB, MessageProcessor {
         bytes memory eventData = abi.encodePacked(header, _data);
 
         emitEventOnMessageRequest(_messageId, eventData);
-        _maybeRelayDataWithHashi(eventData);
+        _maybeSendDataWithHashi(eventData);
 
         return _messageId;
     }


### PR DESCRIPTION
As it could be possible that the majority of the adapters become inactive, there could be a recovery mechanism that allows to resend an already sent but not executed (on the destination chain) message. In this way it could be possible to:
* change the adapters (and reporters)
* `resendDataWithHashi`
* execute the message on the destination chain