### PR TITLE
feat: add possibility to resend an hashi message [xDAI]

### DIFF
--- a/contracts/upgradeable_contracts/BasicForeignBridge.sol
+++ b/contracts/upgradeable_contracts/BasicForeignBridge.sol
@@ -52,6 +52,7 @@ contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge, BasicTo
     ) external returns (bytes) {
         _validateHashiMessage(chainId, threshold, sender, adapters);
         bytes32 msgId = keccak256(data);
+        require(!isApprovedByHashi(msgId));
         _setHashiApprovalForMessage(msgId, true);
     }
 
@@ -61,7 +62,7 @@ contract BasicForeignBridge is EternalStorage, Validatable, BasicBridge, BasicTo
         uint256 currentNonce = nonce();
         setNonce(currentNonce + 1);
         emit UserRequestForAffirmation(_receiver, _amount, bytes32(currentNonce));
-        _maybeRelayDataWithHashi(abi.encodePacked(_receiver, _amount, bytes32(currentNonce)));
+        _maybeSendDataWithHashi(abi.encodePacked(_receiver, _amount, bytes32(currentNonce)));
     }
 
     /**

--- a/contracts/upgradeable_contracts/BasicHomeBridge.sol
+++ b/contracts/upgradeable_contracts/BasicHomeBridge.sol
@@ -76,6 +76,7 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge, BasicToken
     ) external returns (bytes) {
         _validateHashiMessage(chainId, threshold, sender, adapters);
         bytes32 msgId = keccak256(data);
+        require(!isApprovedByHashi(msgId));
         _setHashiApprovalForMessage(msgId, true);
     }
 
@@ -121,7 +122,7 @@ contract BasicHomeBridge is EternalStorage, Validatable, BasicBridge, BasicToken
         uint256 currentNonce = nonce();
         setNonce(currentNonce + 1);
         emit UserRequestForSignature(_receiver, _amount, bytes32(currentNonce));
-        _maybeRelayDataWithHashi(abi.encodePacked(_receiver, _amount, bytes32(currentNonce)));
+        _maybeSendDataWithHashi(abi.encodePacked(_receiver, _amount, bytes32(currentNonce)));
     }
 
     function setMessagesSigned(bytes32 _hash, bool _status) internal {


### PR DESCRIPTION
As it could be possible that the majority of the adapters become inactive, there could be a recovery mechanism that allows to resend an already sent but not executed (on the destination chain) message. In this way it could be possible to:
* change the adapters (and reporters)
* `resendDataWithHashi`
* execute the message on the destination chain